### PR TITLE
Add Erlang/OTP 24 compatibility

### DIFF
--- a/lib/s3_direct_upload.ex
+++ b/lib/s3_direct_upload.ex
@@ -141,8 +141,10 @@ defmodule S3DirectUpload do
     "#{upload.path}/#{upload.file_name}"
   end
 
-  defp hmac(key, data) do
-    :crypto.hmac(:sha256, key, data)
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp hmac(key, data), do: :crypto.mac(:hmac, :sha256, key, data)
+  else
+    defp hmac(key, data), do: :crypto.hmac(:sha256, key, data)
   end
 
   defp access_key, do: Application.get_env(:s3_direct_upload, :aws_access_key)

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule S3DirectUpload.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :crypto]]
   end
 
   # Dependencies


### PR DESCRIPTION
In OTP 24 the `crypto:hmac` function was removed in favour of `crypto:mac`.

This PR adds support for OTP 24 whilst maintaining backwards compatibility for older versions.